### PR TITLE
[Feat] #44 퀴즈 페이지 / 알람 api 연결

### DIFF
--- a/public/firebase-messaging-sw.js
+++ b/public/firebase-messaging-sw.js
@@ -1,11 +1,15 @@
 // 푸시 알림 수신 이벤트 리스너
 self.addEventListener('push', function (event) {
-    const data = event.data.json();
+    const data = event.data?.json?.() || {};
+    console.log('[SW] 푸시 수신 payload:', data);
 
-    // 알림을 표시
-    self.registration.showNotification(data.notification.title, {
-        body: data.notification.body, // 알림 본문 텍스트
-        icon: '/profileImage.png', // 알림에 표시할 아이콘
+    const notification = data.notification || data;
+    const title = notification.title || '알림';
+    const body = notification.body || '새 알림이 도착했습니다';
+
+    self.registration.showNotification(title, {
+        body,
+        icon: '/profileImage.png',
     });
 });
 

--- a/src/api/alaram/fcmTokenAPI.ts
+++ b/src/api/alaram/fcmTokenAPI.ts
@@ -1,0 +1,22 @@
+import api from '@/api/api';
+
+// FCM 토큰 등록
+export const registerFcmToken = async (fcmToken: string) => {
+  const response = await api.post('/api/users/fcm-tokens', { fcmToken });
+  console.log(response);
+  return response.data;
+};
+
+// FCM 토큰 조회
+export const fetchFcmTokens = async () => {
+  const response = await api.get('/api/users/fcm-tokens');
+  console.log(response);
+  return response.data;
+};
+
+// FCM 토큰 삭제
+export const deleteFcmToken = async (token: string) => {
+  const response = await api.delete(`/api/users/fcm-tokens/${token}`);
+  console.log(response);
+  return response.data;
+};

--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -1,0 +1,47 @@
+import axios from 'axios';
+
+const BASE_URL = import.meta.env.VITE_API_BASE_URL;
+
+const api = axios.create({
+  baseURL: BASE_URL,
+  headers: {
+    'Content-Type': 'application/json',
+  },
+});
+
+// 요청 인터셉터 설정
+api.interceptors.request.use(
+  (config) => {
+    const accessToken = localStorage.getItem('accessToken');
+    if (accessToken) {
+      config.headers.Authorization = `Bearer ${accessToken}`;
+    }
+    return config;
+  },
+  (error) => {
+    return Promise.reject(error);
+  },
+);
+
+// 응답 인터셉터
+api.interceptors.response.use(
+  (response) => response,
+  (error) => {
+    // JWT 만료나 인증 실패 등의 응답 처리
+    const message = error?.response?.data?.message || '';
+
+    const isTokenExpired =
+      (error.response?.status === 401 || error.response?.status === 500) &&
+      message.includes('JWT expired');
+
+    if (isTokenExpired) {
+      console.warn('만료된 토큰입니다.');
+      localStorage.clear();
+      window.location.href = '/'; // 홈 또는 로그인 페이지로 이동
+    }
+
+    return Promise.reject(error);
+  },
+);
+
+export default api;

--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -30,9 +30,7 @@ api.interceptors.response.use(
     // JWT 만료나 인증 실패 등의 응답 처리
     const message = error?.response?.data?.message || '';
 
-    const isTokenExpired =
-      (error.response?.status === 401 || error.response?.status === 500) &&
-      message.includes('JWT expired');
+    const isTokenExpired = error.response?.status === 401 && message.includes('JWT expired');
 
     if (isTokenExpired) {
       console.warn('만료된 토큰입니다.');

--- a/src/api/quiz/quizAPI.ts
+++ b/src/api/quiz/quizAPI.ts
@@ -1,0 +1,82 @@
+// src/apis/quizAPI.ts
+import api from '@/api/api';
+
+// 퀴즈 응답 타입 정의
+export type QuizItem = {
+  quizId: number;
+  type: 'OX' | 'MCQ';
+  question: string;
+  options: string[];
+};
+
+export type QuizResponse = {
+  success: boolean;
+  data: QuizItem[];
+  error?: {
+    code: number;
+    message: string;
+    exceptionMessage?: string;
+  };
+};
+
+// 퀴즈 정답 결과 타입
+export type QuizAnswerResult = {
+  quizId: number;
+  isCorrect: boolean;
+  selectedAnswer: string;
+  answer: string;
+  answerDescription: string;
+};
+
+// 퀴즈 정답 제출 요청 타입
+export type CheckAnswerRequest = {
+  quizId: number;
+  selectedAnswer: string;
+};
+
+// 퀴즈 정답 제출 응답 타입
+export type CheckAnswerResponse = {
+  success: boolean;
+  data: QuizAnswerResult;
+  error: {
+    code: number;
+    message: string;
+    exceptionMessage: string;
+  };
+};
+
+// 퀴즈 결과 및 보상 조회 응답 타입
+export type QuizResultResponse = {
+  success: boolean;
+  data: {
+    correctCount: number;
+    coinReward: number;
+    checkQuizResponse: QuizAnswerResult[];
+  };
+  error: {
+    code: number;
+    message: string;
+    exceptionMessage?: string;
+  };
+};
+
+// 오늘의 퀴즈 목록
+export const fetchTodayQuiz = async (): Promise<QuizResponse> => {
+  const response = await api.get<QuizResponse>('/api/quiz/today');
+  console.log(response);
+  return response.data;
+};
+
+// 퀴즈 정답 제출
+export const checkAnswer = async (body: CheckAnswerRequest): Promise<CheckAnswerResponse> => {
+  const response = await api.post<CheckAnswerResponse>('/api/quiz/check', body);
+  console.log(response);
+  return response.data;
+};
+
+// 퀴즈 결과 및 보상 조회
+export const fetchQuizResult = async (): Promise<QuizResultResponse> => {
+  const response = await api.get<QuizResultResponse>('/api/quiz/result');
+  console.log(response);
+  return response.data;
+};

--- a/src/api/quiz/quizAPI.ts
+++ b/src/api/quiz/quizAPI.ts
@@ -63,20 +63,17 @@ export type QuizResultResponse = {
 // 오늘의 퀴즈 목록
 export const fetchTodayQuiz = async (): Promise<QuizResponse> => {
   const response = await api.get<QuizResponse>('/api/quiz/today');
-  console.log(response);
   return response.data;
 };
 
 // 퀴즈 정답 제출
 export const checkAnswer = async (body: CheckAnswerRequest): Promise<CheckAnswerResponse> => {
   const response = await api.post<CheckAnswerResponse>('/api/quiz/check', body);
-  console.log(response);
   return response.data;
 };
 
 // 퀴즈 결과 및 보상 조회
 export const fetchQuizResult = async (): Promise<QuizResultResponse> => {
   const response = await api.get<QuizResultResponse>('/api/quiz/result');
-  console.log(response);
   return response.data;
 };

--- a/src/components/ui/Timer/Timer.tsx
+++ b/src/components/ui/Timer/Timer.tsx
@@ -1,7 +1,7 @@
 import { ReactComponent as TimerIcon } from '@/assets/icons/timerIcon.svg';
 import type { TimerProps } from './Timer.types';
 import { motion } from 'framer-motion';
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useRef } from 'react';
 
 // 컴포넌트 구성 - [아이콘] [프로그레스바] [남은 시간]
 
@@ -15,6 +15,16 @@ const Timer = ({ showSeconds = true, duration = 15, onComplete }: TimerProps) =>
     setIsActive(true);
   }, [duration]);
 
+  // onComplete 중복 호출 방지용 ref
+  const hasCompleted = useRef(false);
+
+  // duration 변경되면 타이머 초기화
+  useEffect(() => {
+    setRemainingTime(duration);
+    setIsActive(true);
+    hasCompleted.current = false; // 완료 플래그 초기화
+  }, [duration]);
+
   //  타이머 감소 로직
   useEffect(() => {
     if (!isActive) return;
@@ -24,7 +34,10 @@ const Timer = ({ showSeconds = true, duration = 15, onComplete }: TimerProps) =>
         if (prev <= 1) {
           clearInterval(interval);
           setIsActive(false);
-          onComplete?.();
+          if (!hasCompleted.current) {
+            hasCompleted.current = true;
+            onComplete?.();
+          }
           return 0;
         }
         return prev - 1;
@@ -32,7 +45,7 @@ const Timer = ({ showSeconds = true, duration = 15, onComplete }: TimerProps) =>
     }, 1000);
 
     return () => clearInterval(interval);
-  }, [isActive]);
+  }, [isActive, onComplete]);
 
   return (
     <div className='relative w-full max-w-[320px] h-[48px]'>

--- a/src/features/quiz/quizFlow/quizSolve/QuizBody.tsx
+++ b/src/features/quiz/quizFlow/quizSolve/QuizBody.tsx
@@ -5,6 +5,11 @@ import type { QuizFlowProps } from '@/types/quizView';
 
 // 퀴즈 본문 내용 렌더링 (QuizContent + QuizResult)
 
+type QuizBodyProps = QuizFlowProps & {
+  isCorrect: boolean;
+  answerDescription: string;
+};
+
 const QuizBody = ({
   step,
   questionNumber,
@@ -14,40 +19,47 @@ const QuizBody = ({
   correctCount,
   onSelect,
   onTimeout,
-}: QuizFlowProps) => {
+  isCorrect,
+  answerDescription,
+}: QuizBodyProps) => {
+  const isQuizStep = step === 'quiz';
+  const isResultStep = step === 'result' || step === 'final';
+
+  const resultDescription =
+    step === 'result' ? answerDescription : '정답 해설은 아래 해답에서 확인해 보세요.';
+
+  const containerPadding = {
+    quiz: 'pt-0',
+    result: 'pt-[120px]',
+    final: 'pt-[100px]',
+  }[step];
+
   return (
     <div
       className={clsx(
         'w-full max-w-[480px] min-w-[360px] mx-auto flex items-center flex-col',
-        step === 'quiz' && 'pt-0',
-        step === 'result' && 'pt-[120px]',
-        step === 'final' && 'pt-[100px]',
+        containerPadding,
       )}
     >
       <div className='relative'>
         {/* step === quiz일 경우 퀴즈 문항 화면 렌더링 */}
-        {step === 'quiz' && (
+        {isQuizStep && (
           <QuizContent
             questionNumber={questionNumber}
             quiz={quiz}
             selectedAnswer={selectedAnswer}
             onSelect={onSelect}
-            onTimeout={onTimeout} // 타임아웃 시 콜백
+            onTimeout={onTimeout}
           />
         )}
         {/* step이 result 또는 final일 경우 결과 화면 렌더링 */}
-        {(step === 'result' || step === 'final') && (
+        {isResultStep && (
           <QuizResult
-            isCorrect={step === 'result' ? selectedAnswer === quiz.answerIndex : false}
+            isCorrect={step === 'result' ? isCorrect : false}
             isLast={isLastQuestion}
             correctCount={correctCount}
             step={step}
-            //  result면 해설, final이면 정답 해설 안내
-            description={
-              step === 'result'
-                ? quiz.answerDescription
-                : '정답 해설은 아래 해답에서 확인해 보세요.'
-            }
+            description={resultDescription}
           />
         )}
       </div>

--- a/src/features/quiz/quizFlow/quizSolve/QuizContent.tsx
+++ b/src/features/quiz/quizFlow/quizSolve/QuizContent.tsx
@@ -8,6 +8,11 @@ import type { BaseQuizProps } from '@/types/quizView';
 
 type QuizContentProps = BaseQuizProps;
 
+const OX_OPTIONS: Record<'O' | 'X', number> = {
+  O: 0,
+  X: 1,
+};
+
 const QuizContent = ({
   questionNumber,
   quiz,
@@ -20,7 +25,7 @@ const QuizContent = ({
       {/* 타이머 영역 */}
       <div className='flex justify-center pt-14 py-[18px]'>
         {/* 타이머가 끝나면 onTimeout 콜백 호출 */}
-        <Timer onComplete={onTimeout} />
+        <Timer key={questionNumber} onComplete={onTimeout} />
       </div>
 
       {/* 퀴즈 컨텐츠 영역 */}
@@ -31,8 +36,16 @@ const QuizContent = ({
         {/* 퀴즈 타입이 'OX'일 경우 */}
         {quiz.type === 'OX' ? (
           <div className='flex gap-4 mt-[48px]'>
-            <QuizOXButton type='o' selected={selectedAnswer === 0} onClick={() => onSelect(0)} />
-            <QuizOXButton type='x' selected={selectedAnswer === 1} onClick={() => onSelect(1)} />
+            <QuizOXButton
+              type='o'
+              selected={selectedAnswer === OX_OPTIONS.O}
+              onClick={() => onSelect(OX_OPTIONS.O)}
+            />
+            <QuizOXButton
+              type='x'
+              selected={selectedAnswer === OX_OPTIONS.X}
+              onClick={() => onSelect(OX_OPTIONS.X)}
+            />
           </div>
         ) : (
           // 객관식 보기인 경우

--- a/src/features/quiz/quizResult/QuizResult.tsx
+++ b/src/features/quiz/quizResult/QuizResult.tsx
@@ -8,6 +8,7 @@ const QuizResult = ({
   isLast = false,
   correctCount = 0,
   step = 'result',
+  totalCount = 3,
 }: QuizResultProps) => {
   // 정답/오답 텍스트
   const resultText = isCorrect ? '정답입니다!' : '오답입니다!';
@@ -24,7 +25,8 @@ const QuizResult = ({
           {/* 맞힌 문제 수 */}
           <div className='flex flex-col items-center gap-0 mt-[42px]'>
             <div className='body-16-r' style={{ lineHeight: '25px' }}>
-              {correctCount}/3
+              {/* TODO: correctCount 서버 응답 확인 필요 */}
+              {correctCount}/{totalCount}
             </div>
             <div className='head-24-eb text-center'>총 {correctCount}문제를 맞히셨습니다!</div>
           </div>

--- a/src/features/quiz/quizResult/QuizResult.types.ts
+++ b/src/features/quiz/quizResult/QuizResult.types.ts
@@ -5,4 +5,6 @@ export type QuizResultProps = QuizResultBlockProps & {
   isLast?: boolean;
   correctCount?: number;
   step?: 'result' | 'final';
+  totalCount?: number;
+  coinReward?: number; // 코인 보상
 };

--- a/src/pages/quiz/QuizPage.tsx
+++ b/src/pages/quiz/QuizPage.tsx
@@ -1,12 +1,14 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { useToast } from '@/contexts/ToastContext';
 import { useNavigate } from 'react-router-dom';
-import { quizMockData } from '@/mocks/quizMock';
+// import { quizMockData } from '@/mocks/quizMock';
 import GlobalTopNav from '@/components/ui/Nav/GlobalTopNav';
 import QuizBody from '@/features/quiz/quizFlow/quizSolve/QuizBody';
 import QuizFooter from '@/features/quiz/quizFlow/quizSolve/QuizFooter';
 import QuizSummary from '@/features/quiz/quizFlow/QuizSummary';
+import { useLocation } from 'react-router-dom';
 import { Modal } from '@/components/ui/Modal';
+import { checkAnswer, fetchQuizResult } from '@/api/quiz/quizAPI';
 
 // 퀴즈 (문제 풀이) / 퀴즈 결과 / 최종 결과 화면
 
@@ -19,81 +21,118 @@ const TIMEOUT_DELAY = 1000;
 const QuizPage = () => {
   const { showToast } = useToast();
   const navigate = useNavigate();
+  const location = useLocation();
+
+  const quizData = location.state;
+  const quizList = quizData?.quizList || [];
 
   // step - 문제 풀이(quiz), 결과(result), 최종 결과(final)
   const [step, setStep] = useState<QuizStep>('quiz');
   const [currentQuestionIndex, setCurrentQuestionIndex] = useState(0); // 현재 퀴즈 인덱스
   const [selectedAnswer, setSelectedAnswer] = useState<Answer>(null); // 사용자가 선택한 답변
   const [userAnswers, setUserAnswers] = useState<number[]>([]); // 사용자 답변 저장
+
   const [correctCount, setCorrectCount] = useState(0); // 정답 개수
+  const [answerExplanation, setAnswerExplanation] = useState('');
+  const [isCorrect, setIsCorrect] = useState(false);
+
   const [showSummary, setShowSummary] = useState(false); // 최종 결과 화면 이동 여부
   const [showExitModal, setShowExitModal] = useState(false);
 
-  const currentQuiz = quizMockData.quizList[currentQuestionIndex]; // 현재 퀴즈 정보
-  const isLastQuestion = currentQuestionIndex === quizMockData.quizList.length - 1; // 마지막 문제 여부
+  const currentQuiz = quizList[currentQuestionIndex]; // 현재 퀴즈 정보
+  const isLastQuestion = currentQuestionIndex === quizList.length - 1; // 마지막 문제 여부
 
   // 답변 선택 시 호출
   const handleSelect = (index: number) => setSelectedAnswer(index);
 
   // 제한 시간 초과 시 호출
-  const handleTimeout = () => {
-    if (selectedAnswer === null) {
-      setSelectedAnswer(-1); // 오답 처리
-      setTimeout(() => handleNextStep(), TIMEOUT_DELAY);
-    }
+  const handleTimeout = async () => {
+    const timeoutIndex = -1;
+    setSelectedAnswer(timeoutIndex);
+
+    await processAnswer(timeoutIndex); // 서버에 오답 처리 요청
+    setTimeout(() => setStep('result'), TIMEOUT_DELAY);
   };
 
   // 정답 처리 로직
-  const processAnswer = () => {
-    const isCorrect = selectedAnswer === currentQuiz.answerIndex;
+  const processAnswer = async (index: number) => {
+    const selected = currentQuiz.options[index] || '';
+    try {
+      const res = await checkAnswer({
+        quizId: currentQuiz.quizId,
+        selectedAnswer: selected,
+      });
 
-    if (isCorrect) {
-      setCorrectCount((prev) => prev + 1);
-      showToast({ message: '치카코인 1개가 적립되었어요.', duration: TOAST_DURATION });
+      const { isCorrect, answerDescription } = res.data;
+
+      setIsCorrect(isCorrect);
+      setAnswerExplanation(answerDescription);
+      if (isCorrect) {
+        setCorrectCount((prev) => prev + 1);
+        showToast({ message: '치카코인 1개가 적립되었어요.', duration: TOAST_DURATION });
+      }
+    } catch {
+      showToast({ message: '정답 확인 중 오류가 발생했어요.', duration: TOAST_DURATION });
+      setIsCorrect(false);
+      setAnswerExplanation('정답 확인 실패');
     }
 
-    setUserAnswers((prev) => [...prev, selectedAnswer ?? -1]);
+    setUserAnswers((prev) => [...prev, index]);
+    setStep('result');
   };
 
   // 다음 단계로 전환
   const handleNextStep = () => {
     if (step === 'quiz') {
-      processAnswer();
-      setStep('result'); // 결과 화면으로 전환
+      if (selectedAnswer === null) return;
+      processAnswer(selectedAnswer);
     } else if (step === 'result') {
       if (isLastQuestion) {
         showToast({
           message: `총 치카코인 ${correctCount}개를 획득하였습니다.`,
           duration: TOAST_DURATION,
         });
-        setStep('final'); // 최종 결과로 전환
+        setStep('final');
       } else {
-        // 다음 문제로 넘어가기
         setCurrentQuestionIndex((prev) => prev + 1);
         setSelectedAnswer(null);
+        setAnswerExplanation('');
         setStep('quiz');
       }
     }
   };
 
-  const handleLeftClick = () => {
-    setShowExitModal(true);
-  };
+  const handleLeftClick = () => setShowExitModal(true);
 
   const confirmExit = () => {
     setShowExitModal(false);
     navigate('/quiz/start'); // 퀴즈 초기화됨
   };
 
+  //최종 결과 도달 시 최종 결과 API 호출
+  useEffect(() => {
+    const fetchFinalResult = async () => {
+      if (step !== 'final') return;
+
+      try {
+        const res = await fetchQuizResult();
+        const { correctCount, coinReward } = res.data;
+
+        setCorrectCount(correctCount); // API 기준 정답 수로 갱신
+        setAnswerExplanation(`치카코인 ${coinReward}개가 적립되었어요!`);
+      } catch {
+        showToast({ message: '최종 결과 조회 중 오류가 발생했어요.', duration: TOAST_DURATION });
+      }
+    };
+
+    fetchFinalResult();
+  }, [step]);
+
   return (
     <div className='relative min-h-screen pt-[18px] flex justify-start items-center flex-col'>
       <GlobalTopNav message='퀴즈' showCancel={false} onClickLeft={handleLeftClick} />
       {showSummary ? (
-        <QuizSummary
-          quizList={quizMockData.quizList.map((q) => ({ ...q }))}
-          userAnswers={userAnswers}
-          onClose={() => navigate('/')}
-        />
+        <QuizSummary quizList={quizList} userAnswers={userAnswers} onClose={() => navigate('/')} />
       ) : (
         <>
           {/* 본문 (문제 / 결과) */}
@@ -106,6 +145,8 @@ const QuizPage = () => {
             correctCount={correctCount}
             onSelect={handleSelect}
             onTimeout={handleTimeout}
+            isCorrect={isCorrect}
+            answerDescription={answerExplanation}
           />
           {/* 하단 버튼 영역 (다음 버튼 / 결과 보기) */}
           <QuizFooter

--- a/src/pages/quiz/QuizStartPage.tsx
+++ b/src/pages/quiz/QuizStartPage.tsx
@@ -1,9 +1,28 @@
 import StartPageTemplate from '@/features/start/StartPageTemplate';
 import image from '@/assets/images/quizStart.png';
 import { useNavigate } from 'react-router-dom';
+import { fetchTodayQuiz } from '@/api/quiz/quizAPI';
+import { useState } from 'react';
 
 const QuizStartPage = () => {
   const navigate = useNavigate();
+  const [loading, setLoading] = useState(false);
+
+  const handleStart = async () => {
+    try {
+      setLoading(true);
+      const data = await fetchTodayQuiz();
+      if (data.success) {
+        navigate('/quiz', { state: data.data }); // 퀴즈 데이터 넘기기
+      } else {
+        console.error(data.error?.message || '퀴즈 데이터를 불러오지 못했습니다.');
+      }
+    } catch (error) {
+      console.error('퀴즈 요청 중 오류가 발생했습니다.', error);
+    } finally {
+      setLoading(false);
+    }
+  };
 
   return (
     <StartPageTemplate
@@ -13,7 +32,8 @@ const QuizStartPage = () => {
       title='매일 퀴즈 도전하기'
       coinText='획득 치카코인'
       noticeList={['문항 수', '객관식, OX', '중도 이탈', '결과 확인']}
-      onStart={() => navigate('/quiz')}
+      onStart={handleStart}
+      startButtonText={loading ? '불러오는 중...' : '시작하기'} // 임시
     />
   );
 };

--- a/src/utils/firebaseMessaging.ts
+++ b/src/utils/firebaseMessaging.ts
@@ -1,6 +1,6 @@
 import { initializeApp } from 'firebase/app';
 import { getMessaging, onMessage, getToken } from 'firebase/messaging';
-import { registerFcmToken } from '@/api/alaram/fcmToken';
+import { registerFcmToken } from '@/api/alaram/fcmTokenAPI';
 
 const firebaseConfig = {
   apiKey: import.meta.env.VITE_FIREBASE_API_KEY,

--- a/src/utils/firebaseMessaging.ts
+++ b/src/utils/firebaseMessaging.ts
@@ -1,5 +1,6 @@
 import { initializeApp } from 'firebase/app';
 import { getMessaging, onMessage, getToken } from 'firebase/messaging';
+import { registerFcmToken } from '@/api/alaram/fcmToken';
 
 const firebaseConfig = {
   apiKey: import.meta.env.VITE_FIREBASE_API_KEY,
@@ -28,7 +29,7 @@ async function requestFcmToken() {
     const currentToken = await getToken(messaging, { vapidKey: VAPID_KEY });
     if (currentToken) {
       console.log('FCM Token:', currentToken);
-      //TODO: 여기에 서버로 토큰 전송하는 로직 추가
+      await registerFcmToken(currentToken);
       return currentToken;
     } else {
       console.log('No registration token available.');


### PR DESCRIPTION
## 🔗 관련 이슈

- close #44 

<br>

## 📌 작업사항

- axios 인스턴스 생성
- 퀴즈 조회 / 정답 제출 / 결과 조회 api 연결
- FCM 토큰 발급 / 조회 / 삭제 api 연결 + 알림 테스트
- Timer 컴포넌트 리팩토링  

<br>

## 🗒️ 참고사항
- 현재 accessToken 재발급 api가 따로 없어서 토큰 만료 시 자동 로그아웃되게 해뒀습니다! 추후 추가된다면 수정하겠습니다~
- 퀴즈 결과 및 보상 조회 부분은 잘 작동하는 거 확인했는데, 퀴즈를 하루 한 번만 풀 수 있어서 현재는 `success:false`로 뜹니당
- FCM 토큰 발급 후 웹 푸시 알림 잘 오는 것까지 확인 완료했습니다 👍

<br>

## 📸 스크린샷

<!-- UI 변경 사항이 있다면, 관련 스크린샷을 첨부해주세요. -->

- FCM 토큰 발급 성공 
<img width="707" height="204" alt="image" src="https://github.com/user-attachments/assets/2d7e64df-e5f9-4bf5-87db-87724c7e7201" />

- 퀴즈 조회 / 정답 제출 / 결과 조회 성공 
<img width="709" height="345" alt="image" src="https://github.com/user-attachments/assets/fcf15081-70ec-4637-9b76-c1d92733e7e8" />
<img width="719" height="123" alt="image" src="https://github.com/user-attachments/assets/f0047644-9650-4f76-8e9e-f5975973c1b8" />


<br>

## ✅ 체크리스트

<!-- PR을 제출하기 전에 확인해야 할 항목들 -->

- [x] 로컬에서 빌드 및 테스트 완료
- [x] Label 지정 완료
- [x] 리뷰어 지정 완료
- [ ] 코드 리뷰 반영 완료
- [ ] 문서화 필요 여부 확인

<br>