### PR TITLE
[Feat] #50 회원가입 만 14세 미만 판단 로직 구현

### DIFF
--- a/src/features/signup/SignupInfo.tsx
+++ b/src/features/signup/SignupInfo.tsx
@@ -1,9 +1,10 @@
 import Button from '@/components/ui/Button';
 import { useState } from 'react';
 import UserInfoForm from '@/components/ui/UserInfoForm';
+import { isOver14 } from '@/utils/date';
 
 interface Props {
-  onNext: () => void;
+  onNext: (nextStep: 'complete' | 'guardianIntro') => void;
 }
 
 const SignupInfo = ({ onNext }: Props) => {
@@ -11,6 +12,11 @@ const SignupInfo = ({ onNext }: Props) => {
   const [birthDate, setBirthDate] = useState('');
 
   const isFormIncomplete = !gender || !birthDate;
+
+  const handleNext = () => {
+    const nextStep = isOver14(birthDate) ? 'complete' : 'guardianIntro';
+    onNext(nextStep);
+  };
 
   return (
     <>
@@ -92,7 +98,7 @@ const SignupInfo = ({ onNext }: Props) => {
       >
         <Button
           variant='primary'
-          onClick={onNext}
+          onClick={handleNext}
           size='large'
           fullWidth={true}
           disabled={isFormIncomplete}

--- a/src/pages/auth/SignupPage.tsx
+++ b/src/pages/auth/SignupPage.tsx
@@ -39,7 +39,7 @@ function SignupPage() {
       <GlobalTopNav type='signup' message='' onClickLeft={handleBack} />
       <div>
         {step === 'profile' && <SignupProfile onNext={() => goToNext('info')} />}
-        {step === 'info' && <SignupInfo onNext={() => goToNext('guardianIntro')} />}
+        {step === 'info' && <SignupInfo onNext={(nextStep) => goToNext(nextStep)} />}
         {step === 'guardianIntro' && (
           <SignupGuardianIntro onNext={() => goToNext('guardianForm')} />
         )}

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -1,0 +1,11 @@
+import dayjs from 'dayjs';
+
+//만 14세 이상 판단 함수
+export const isOver14 = (birthDate: string): boolean => {
+  const today = dayjs();
+  const birth = dayjs(birthDate, 'YYYY.MM.DD');
+  const fourteenYearsLater = birth.add(14, 'year');
+  // 생일 + 14년 >= today : false(만 14세 미만)
+  // 생일 + 14년 < today: true(만 14세 이상)
+  return !fourteenYearsLater.isAfter(today);
+};


### PR DESCRIPTION
## 🔗 관련 이슈

- close #50 

<br>

## 📌 작업사항

- /utils/date.ts 파일 생성(만 14세 이상/미만 판단 함수)
- SignupInfo & SignupPage에 해당 로직 반영 

<br>

## 🗒️ 참고사항

#47 내용이 머지되지 않아서 로그인 디자인이 반영 안된 상태입니다

- 만 14세 미만 판단 기준 
생일 + 14년 >= today : false(만 14세 미만)
생일 + 14년 < today: true(만 14세 이상)

false의 경우: profile -> info ->  guardianintro -> guardianform -> complete 
true의 경우: profile -> info -> complete

<br>

## 📸 스크린샷

https://github.com/user-attachments/assets/55024dbb-ded4-43a7-9e6d-cf5d8fe0d617


<br>

## ✅ 체크리스트

<!-- PR을 제출하기 전에 확인해야 할 항목들 -->

- [ ] 로컬에서 빌드 및 테스트 완료
- [ ] Label 지정 완료
- [ ] 리뷰어 지정 완료
- [ ] 코드 리뷰 반영 완료
- [ ] 문서화 필요 여부 확인
