### PR TITLE
[refactor] #77 홈 리팩토링

### DIFF
--- a/src/components/ui/Nav/HomeTopNav.tsx
+++ b/src/components/ui/Nav/HomeTopNav.tsx
@@ -6,7 +6,7 @@ export const HomeTopNav = () => {
   return (
     <div className='fixed top-0 left-1/2 -translate-x-1/2 w-full max-w-[480px] min-w-[360px] p-[10px_20px] h-14 flex items-center justify-between bg-bg-tertiary-gray z-999'>
       <HomeLogo />
-      <Link to='/'>
+      <Link to='/mypage/alarm'>
         <BellIcon />
       </Link>
     </div>

--- a/src/features/Home/homeBanner/HomeBanner.tsx
+++ b/src/features/Home/homeBanner/HomeBanner.tsx
@@ -1,4 +1,4 @@
-import Background from '@/assets/images/home_background.svg';
+import { ReactComponent as Background } from '@/assets/images/home_background.svg';
 import { ReactComponent as Rabbit } from '@/assets/icons/rabbit.svg';
 import { ReactComponent as Toothbrush } from '@/assets/icons/toothbrush.svg';
 import CoinCount from './CoinCount';
@@ -6,11 +6,7 @@ import CoinCount from './CoinCount';
 const HomeBanner = () => {
   return (
     <div className='relative max-w-[480px] min-w-[360px] w-full h-[340px] mx-auto'>
-      <img
-        src={Background}
-        alt='홈 배경'
-        className='absolute inset-0 w-full h-full object-cover object-bottom z-0'
-      />
+      <Background className='absolute inset-0 w-full h-full object-cover object-bottom z-0' />
       {/* 중앙에 묶어서 배치 */}
       <div className='absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-[-35px] z-10'>
         <Toothbrush className='absolute top-[-80px] left-[-60px]' />

--- a/src/features/Home/homeBanner/HomeBanner.tsx
+++ b/src/features/Home/homeBanner/HomeBanner.tsx
@@ -1,22 +1,24 @@
-import { ReactComponent as Background } from '@/assets/images/home_background.svg';
-import { ReactComponent as Rabbit } from '@/assets/icons/rabbit.svg';
-import { ReactComponent as Toothbrush } from '@/assets/icons/toothbrush.svg';
+import {ReactComponent as Background} from '@/assets/images/home_background.svg';
+import {ReactComponent as Rabbit} from '@/assets/icons/rabbit.svg';
+import {ReactComponent as Toothbrush} from '@/assets/icons/toothbrush.svg';
 import CoinCount from './CoinCount';
 
 const HomeBanner = () => {
-  return (
-    <div className='relative max-w-[480px] min-w-[360px] w-full h-[340px] mx-auto'>
-      <Background className='absolute inset-0 w-full h-full object-cover object-bottom z-0' />
-      {/* 중앙에 묶어서 배치 */}
-      <div className='absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-[-35px] z-10'>
-        <Toothbrush className='absolute top-[-80px] left-[-60px]' />
-        <Rabbit className='relative w-[71.12px] h-[120px]' />
-      </div>
-      <div className='absolute top-[20.33px] right-[20px] z-10 flex items-center justify-center'>
-        <CoinCount />
-      </div>
-    </div>
-  );
+    return (
+        <div className='relative max-w-[480px] min-w-[360px] w-full h-[340px] mx-auto'>
+            <Background
+                className='absolute inset-0 w-full h-full object-cover object-top z-0'/> 
+            <div
+                className='absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-[-35px] z-10'>
+                <Toothbrush className='absolute top-[-80px] left-[-60px]'/>
+                <Rabbit className='relative w-[71.12px] h-[120px]'/>
+            </div>
+            <div
+                className='absolute top-[20.33px] right-[20px] z-10 flex items-center justify-center'>
+                <CoinCount/>
+            </div>
+        </div>
+    );
 };
 
 export default HomeBanner;

--- a/src/features/Home/todayMission/BrushingSessionList.tsx
+++ b/src/features/Home/todayMission/BrushingSessionList.tsx
@@ -64,18 +64,21 @@ const BrushingSessionList: React.FC<BrushingSessionListProps> = ({ cards }) => {
   return (
     <div
       ref={sliderRef}
-      className={`pb-[8px] w-full snap-x scroll-smooth overflow-x-hidden overflow-y-hidden flex no-scrollbar select-none mt-[18px] 
-        ${isDragging ? 'cursor-grabbing' : 'cursor-grab'}
-      `}
+      className={`pb-[8px] w-full snap-x scroll-smooth overflow-x-auto overflow-y-hidden flex no-scrollbar select-none mt-[18px]`
+        + ` ${isDragging ? 'cursor-grabbing' : 'cursor-grab'}`}
+      style={{
+        paddingLeft: 'env(safe-area-inset-left, 18px)',
+        paddingRight: 'env(safe-area-inset-right, 18px)',
+      }}
       onMouseDown={onMouseDown}
       onMouseMove={onMouseMove}
       onMouseUp={stopDrag}
       onMouseLeave={stopDrag}
     >
       {/* 카드 리스트 */}
-      <div className='flex gap-[15px] pl-[2px] pr-[2px]'>
+      <div className='flex gap-[15px] flex-nowrap w-full'>
         {sortedCards.map((card) => (
-          <div key={card.id} className='snap-start shrink-0'>
+          <div key={card.id} className='snap-start shrink-0 min-w-[140px] max-w-[80vw] w-auto'>
             <BrushingSessionCard
               title={card.title}
               description={card.description}

--- a/src/features/Home/todayMission/BrushingSessionList.tsx
+++ b/src/features/Home/todayMission/BrushingSessionList.tsx
@@ -64,12 +64,9 @@ const BrushingSessionList: React.FC<BrushingSessionListProps> = ({ cards }) => {
   return (
     <div
       ref={sliderRef}
-      className={`pb-[8px] w-full snap-x scroll-smooth overflow-x-auto overflow-y-hidden flex no-scrollbar select-none mt-[18px]`
-        + ` ${isDragging ? 'cursor-grabbing' : 'cursor-grab'}`}
-      style={{
-        paddingLeft: 'env(safe-area-inset-left, 18px)',
-        paddingRight: 'env(safe-area-inset-right, 18px)',
-      }}
+      className={`pb-[8px] w-full snap-x scroll-smooth overflow-x-auto overflow-y-hidden flex no-scrollbar select-none mt-[18px] px-[18px] 
+        ${isDragging ? 'cursor-grabbing' : 'cursor-grab'}
+      `}
       onMouseDown={onMouseDown}
       onMouseMove={onMouseMove}
       onMouseUp={stopDrag}
@@ -78,7 +75,7 @@ const BrushingSessionList: React.FC<BrushingSessionListProps> = ({ cards }) => {
       {/* 카드 리스트 */}
       <div className='flex gap-[15px] flex-nowrap w-full'>
         {sortedCards.map((card) => (
-          <div key={card.id} className='snap-start shrink-0 min-w-[140px] max-w-[80vw] w-auto'>
+          <div key={card.id} className='snap-start shrink-0 min-w-[130px] max-w-[80vw] w-auto'>
             <BrushingSessionCard
               title={card.title}
               description={card.description}

--- a/src/pages/Home/HomePage.tsx
+++ b/src/pages/Home/HomePage.tsx
@@ -59,18 +59,15 @@ const HomePage = () => {
   });
 
   return (
-    <div className='max-w-[430px] min-w-[360px] w-full min-h-screen flex flex-col items-center mx-auto'>
+    <div className='w-screen max-w-full min-h-screen h-full flex flex-col items-center mx-auto'>
       {/* 홈 헤더 */}
       <HomeTopNav />
       <div className='h-14' />
 
       {/* 홈 배너 이미지 */}
-      <div className='left-0 h-14'>
-        <div className='w-screen flex justify-center'>
-          <HomeBanner />
-        </div>
+      <div className='w-full flex justify-center'>
+        <HomeBanner />
       </div>
-      <div className='h-[280px]' />
 
       {/* 날짜+미션 */}
       <div className='w-full pl-[18px] pt-[20px] pb-[25px] flex flex-col mx-auto'>


### PR DESCRIPTION
## 🔗 관련 이슈

- close #77

<br>

## 📌 작업사항

- 알림 아이콘 클릭 → 알림 설정 페이지로 이동되게 설정 추가
- 홈 배너 `width` 깨짐 현상 수정
- 모바일 뷰에서 `BrushingSessionList` 카드 슬라이드가 3개 이상 존재할 때, 불필요한 스크롤 발생 및 `width` 깨짐 현상 수정
- 모바일 뷰에서 `BrushingSessionList` 카드 슬라이드 가능하도록 수정

<br>

## 🗒️ 참고사항
모바일 뷰에서 반응형으로 동작하도록 수정했는데도 `BrushingSessionList` 카드 슬라이드와 `BottomNav` 사이의 불필요한 여백이 존재합니다,, 어느 부분을 수정해야 할까요..??
<br>

## 📸 스크린샷

<!-- UI 변경 사항이 있다면, 관련 스크린샷을 첨부해주세요. -->

https://github.com/user-attachments/assets/23cd7378-0abf-4491-9042-e5843f1d1bc6

<br>

## ✅ 체크리스트

<!-- PR을 제출하기 전에 확인해야 할 항목들 -->

- [x] 로컬에서 빌드 및 테스트 완료
- [x] Label 지정 완료
- [x] 리뷰어 지정 완료
- [ ] 코드 리뷰 반영 완료
- [ ] 문서화 필요 여부 확인
